### PR TITLE
Remove default network add on container creation

### DIFF
--- a/cluster/swarm/cluster.go
+++ b/cluster/swarm/cluster.go
@@ -154,12 +154,6 @@ func (c *Cluster) CreateContainer(config *cluster.ContainerConfig, name string, 
 	log.Debug("CX: Adding label pool=" + poolUUID)
 	config.Labels["pool"] = poolUUID
 
-	OS := os.Getenv("CX_OS")
-	if OS == "linux" {
-		log.Debug("CX: Adding container to the default pool network")
-		config.HostConfig.NetworkMode = containertypes.NetworkMode(poolUUID)
-	}
-
 	container, err := c.createContainer(config, name, false, authConfig)
 
 	if err != nil {


### PR DESCRIPTION
This changeset removes addition of pool default container network when a
container is created. Any networks for container must be specified
explicitly, e.g., using --net option for docker run command. A default
network per pool is still available, and hence may be specified if so
desired.

Git Issue: #7